### PR TITLE
The EVB baseboard adds reception verification

### DIFF
--- a/Projects/PY32F003-STK/Example/USART/uart_adapter/Inc/main.h
+++ b/Projects/PY32F003-STK/Example/USART/uart_adapter/Inc/main.h
@@ -44,6 +44,18 @@ extern "C" {
 
 /* Private includes ----------------------------------------------------------*/
 /* Private defines -----------------------------------------------------------*/
+/**
+ * @defgroup RADAR_WAKEUP_RADAR Wake-up Pin Definition
+ * @brief Radar wake-up pin definition
+ * @{
+ */
+#define RADAR_WAKEUP_PORT        	GPIOF
+#define RADAR_WAKEUP_PIN         	GPIO_PIN_1
+#define RADAR_WAKEUP_CLK_ENABLE() __HAL_RCC_GPIOF_CLK_ENABLE()
+/** 
+ * @} 
+ */
+
 /* Exported variables prototypes ---------------------------------------------*/
 extern UART_HandleTypeDef UartHandle;
 

--- a/Projects/PY32F003-STK/Example/USART/uart_adapter/Src/main.c
+++ b/Projects/PY32F003-STK/Example/USART/uart_adapter/Src/main.c
@@ -329,8 +329,8 @@ void APP_Usart2IRQCallback(USART_TypeDef *USARTx)
 	if ((LL_USART_IsActiveFlag_IDLE(USARTx) != RESET) && (LL_USART_IsEnabledIT_IDLE(USARTx) != RESET)) {
 		LL_USART_ClearFlag_IDLE(USARTx);
 		if (uart_module.rx_cnt > 0) {
-            uart_module.state = UART_STATE_RX_COMPLETE;
-        }
+			uart_module.state = UART_STATE_RX_COMPLETE;
+        	}
 	}
 }
 

--- a/Projects/PY32F003-STK/Example/USART/uart_adapter/Src/main.c
+++ b/Projects/PY32F003-STK/Example/USART/uart_adapter/Src/main.c
@@ -58,6 +58,7 @@ static uint8_t uart_upper_rx_buf[RX_BUF_SIZE];
 static uint8_t uart_module_rx_buf[RX_BUF_SIZE];
 static volatile uart_ctx_t uart_upper;
 static volatile uart_ctx_t uart_module;
+static volatile uint8_t m_radar_ready_flag = 0; /* Flag to indicate whether radar_wakeup_host is high */
 
 /* Private user code ---------------------------------------------------------*/
 
@@ -70,6 +71,7 @@ static void APP_IntPinConfig(void);
 static void APP_RadarOutPinConfig(void);
 static void APP_WakeupPinConfig(void);
 static void APP_UartInit(void);
+static void app_process_radar_rata(void);
 
 /**
  * @brief  应用程序入口函数.
@@ -100,11 +102,18 @@ int main(void)
 			uart_upper.state = UART_STATE_IDLE;
 		}
 		if (uart_module.state == UART_STATE_RX_COMPLETE) {
-			(void)HAL_UART_Transmit(uart_upper.handle, uart_module.rx_buf, uart_module.rx_cnt, 0xFFFFU);
-			uart_module.rx_cnt = 0;
-			uart_module.state = UART_STATE_IDLE;
+			app_process_radar_rata();
 		}
 	}
+}
+
+static void app_process_radar_rata(void)
+{
+    if (uart_module.rx_cnt > 0) {
+        (void)HAL_UART_Transmit(uart_upper.handle, uart_module.rx_buf, uart_module.rx_cnt, 0xFFFFU);
+        uart_module.rx_cnt = 0;
+    }
+    uart_module.state = UART_STATE_IDLE;
 }
 
 /**
@@ -115,6 +124,27 @@ int main(void)
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
 	printf("Uart Error, ErrorCode = %d\r\n", huart->ErrorCode);
+}
+
+void hal_gpio_exti_callback(uint16_t GPIO_Pin)
+{
+    if (GPIO_Pin == RADAR_WAKEUP_PIN) {
+        if (HAL_GPIO_ReadPin(RADAR_WAKEUP_PORT, RADAR_WAKEUP_PIN) == GPIO_PIN_SET) {
+            /* Rising edge detected - Radar has data to send */
+            m_radar_ready_flag = 1;
+            LL_USART_EnableIT_RXNE(USART2);  /* Enable USART2 RXNE interrupt */
+        } else {
+            /* Falling edge detected - Radar data transmission completed */
+            m_radar_ready_flag = 0;
+            LL_USART_DisableIT_RXNE(USART2); /* Disable USART2 RXNE interrupt */
+            
+            /* If there is data to process, handle it immediately */
+            if (uart_module.state == UART_STATE_BUSY_RX && uart_module.rx_cnt > 0) {
+                uart_module.state = UART_STATE_RX_COMPLETE;
+                app_process_radar_rata();
+            }
+        }
+    }
 }
 
 /**
@@ -196,6 +226,20 @@ static void APP_WakeupPinConfig(void)
 	GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
 
 	HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
+
+	/* Configure PF1 (radar_wakeup_host) as an interrupt pin */
+	GPIO_InitStruct.Pin = RADAR_WAKEUP_PIN;
+	GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING_FALLING; /* Detect rising and falling edges */
+	GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+	GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+	HAL_GPIO_Init(RADAR_WAKEUP_PORT, &GPIO_InitStruct);
+	
+	/* Enable and set EXTI interrupt priority */
+	HAL_NVIC_SetPriority(EXTI0_1_IRQn, 0, 0);
+	HAL_NVIC_EnableIRQ(EXTI0_1_IRQn);
+	
+	/* Initialize m_radar_ready_flag based on current pin state */
+	m_radar_ready_flag = (HAL_GPIO_ReadPin(RADAR_WAKEUP_PORT, RADAR_WAKEUP_PIN) == GPIO_PIN_SET) ? 1 : 0;
 }
 
 static void uart_upper_init(void)
@@ -242,8 +286,13 @@ static void uart_module_init(void)
 		APP_ErrorHandler();
 	}
 
-	LL_USART_EnableIT_RXNE(USART2);
-	LL_USART_EnableIT_IDLE(USART2);
+	/* Disable the RXNE interrupt for USART2 during initialization, until m_radar_ready_flag is high */
+    LL_USART_EnableIT_IDLE(USART2);
+    if (m_radar_ready_flag) {
+        LL_USART_EnableIT_RXNE(USART2);
+    } else {
+        LL_USART_DisableIT_RXNE(USART2);
+    }
 }
 
 static void APP_UartInit(void)
@@ -272,14 +321,16 @@ void APP_Usart1IRQCallback(USART_TypeDef *USARTx)
 
 void APP_Usart2IRQCallback(USART_TypeDef *USARTx)
 {
-	if ((LL_USART_IsActiveFlag_RXNE(USARTx) != RESET) && (LL_USART_IsEnabledIT_RXNE(USARTx) != RESET)) {
+	if ((LL_USART_IsActiveFlag_RXNE(USARTx) != RESET) && (LL_USART_IsEnabledIT_RXNE(USARTx) != RESET) && m_radar_ready_flag) {
 		uart_module.rx_buf[uart_module.rx_cnt] = LL_USART_ReceiveData8(USARTx);
 		uart_module.rx_cnt++;
 		uart_module.state = UART_STATE_BUSY_RX;
 	}
 	if ((LL_USART_IsActiveFlag_IDLE(USARTx) != RESET) && (LL_USART_IsEnabledIT_IDLE(USARTx) != RESET)) {
 		LL_USART_ClearFlag_IDLE(USARTx);
-		uart_module.state = UART_STATE_RX_COMPLETE;
+		if (uart_module.rx_cnt > 0) {
+            uart_module.state = UART_STATE_RX_COMPLETE;
+        }
 	}
 }
 

--- a/Projects/PY32F003-STK/Example/USART/uart_adapter/Src/py32f0xx_it.c
+++ b/Projects/PY32F003-STK/Example/USART/uart_adapter/Src/py32f0xx_it.c
@@ -104,4 +104,17 @@ void USART2_IRQHandler(void)
 	APP_Usart2IRQCallback(USART2);
 }
 
+void EXTI0_1_IRQHandler(void)
+{
+    /* Check if the interrupt is triggered by EXTI Line 1 */
+    if (__HAL_GPIO_EXTI_GET_IT(RADAR_WAKEUP_PIN) != RESET)
+    {
+        /* Clear the interrupt flag for EXTI Line 1 */
+        __HAL_GPIO_EXTI_CLEAR_IT(RADAR_WAKEUP_PIN);
+        
+        /* Call the GPIO EXTI callback function */
+        hal_gpio_exti_callback(RADAR_WAKEUP_PIN);
+    }
+}
+
 /************************ (C) COPYRIGHT Puya *****END OF FILE******************/


### PR DESCRIPTION
The EVB baseboard adds reception verification, configuring PF1 to support interrupts for both rising and falling edges to achieve this